### PR TITLE
#20 refactor: 1차인증, 2차인증 로직 허점 개선과 테스트 빌드 버그 해결

### DIFF
--- a/neighbor/src/main/java/com/likelion/neighbor/global/exception/model/Error.java
+++ b/neighbor/src/main/java/com/likelion/neighbor/global/exception/model/Error.java
@@ -22,7 +22,7 @@ public enum Error {
 	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검사에 맞지 않습니다."),
 	PARAMETER_NOT_VALID_ERROR(HttpStatus.BAD_REQUEST, "파라미터가 적절치 않습니다."),
 	EXTENSION_NOT_VALID_ERROR(HttpStatus.BAD_REQUEST, "지원하지 않는 확장자입니다."),
-	EXIST_USER_ERROR(HttpStatus.BAD_REQUEST, "이미 회원가입이 되어있는 유저입니다."),
+	EXIST_USER_ERROR(HttpStatus.BAD_REQUEST, "이미 네이보에 회원가입이 되어있는 유저입니다. 로그인을 해주세요."),
 
 	/**
 	 * 401 UNAUTHORIZED

--- a/neighbor/src/test/java/com/likelion/neighbor/NeighborApplicationTests.java
+++ b/neighbor/src/test/java/com/likelion/neighbor/NeighborApplicationTests.java
@@ -5,9 +5,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class NeighborApplicationTests {
-
-    @Test
-    void contextLoads() {
-    }
+    
 
 }


### PR DESCRIPTION
이거하면서 저도 좀 배웠습니당. orElse()안에 user를 생성하는 private 메소드를 넣었는데, 얘가 기본값으로 반환할 준비를 미리 하면서 이미 user를 save해버리는 현상이 일어나 유저가 이미 findByEmail()로 조회했는데도 불구하고 두번 생성되는 버그가 있었습니다; 😢 그래서 orElseGet으로 지연적으로 해결하도록 변경하였습니당 

테스트 빌드 autowired 제거했고, 정상적으로 빌드되는거 확인했습니당.

1차인증 과정에서 생각을 해보니 유저 존재하는지 빠르게 먼저 파악하고 에러 던져주고 기존 유저면 로그인 바로 하게끔 플로우를 변경했습니당.